### PR TITLE
Update omniauth dependency to allow 1.2 version

### DIFF
--- a/omniauth-deezer.gemspec
+++ b/omniauth-deezer.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   # specify any dependencies here; for example:
-  s.add_runtime_dependency 'omniauth', '~> 1.1.0'
+  s.add_runtime_dependency 'omniauth', '>= 1.1.0'
   s.add_runtime_dependency 'faraday'
   
   # s.add_development_dependency "rspec"


### PR DESCRIPTION
Current version of `omniauth-google-oauth2` enforces me to use omniauth 1.2, but atm omniauth-deezer lets me install only maximum version of `1.1.*`. 

Omniauth 1.2 works okay with `omniauth-deezer`, so let's allow this version also.
